### PR TITLE
Add store edit functionality for store admin users

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -2,4 +2,29 @@ class StoresController < ApplicationController
   def index
     @stores = Store.all
   end
+
+  def edit
+    @store = store
+  end
+
+  def update
+    @store = store
+    if @store.update(store_params)
+      flash[:notice] = "#{@store.name} Updated"
+      redirect_to store_admin_dashboard_path(store, current_user)
+    else
+      flash[:error] = @store.errors.full_messages.join(", ")
+      render :edit
+    end
+  end
+
+  private
+
+  def store_params
+    params.require(:store).permit(:name, :description, :image)
+  end
+
+  def store
+    @store ||= Store.find_by!(slug: params[:id])
+  end
 end

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -38,8 +38,8 @@
           <a href="" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Admin <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li><%= link_to "Dashboard", store_admin_dashboard_path(store: current_user.store, id: current_user) %></li>
-            <li><%= link_to "All Photos", store_admin_photos_path %></li>
-            <li><%= link_to "Create Photo", new_store_admin_photo_path %></li>
+            <li><%= link_to "All Photos", store_admin_photos_path(current_user.store) %></li>
+            <li><%= link_to "Create Photo", new_store_admin_photo_path(current_user.store) %></li>
             <li><%= link_to "All Orders", admin_orders_dashboard_path %></li>
           </ul>
         </li>

--- a/app/views/stores/admin/photos/_form.html.erb
+++ b/app/views/stores/admin/photos/_form.html.erb
@@ -1,10 +1,10 @@
-  <div class="form">
+<div class="form">
   <%= form_for([:admin, @photo]) do |f| %>
     <div><%= f.text_field :title, placeholder: "Photo title"  %><br></div><br>
     <div><%= f.text_field :description, placeholder: "Photo description" %><br></div><br>
     <div><%= f.text_field :price, placeholder: "Price" %><br></div><br>
-  <div><%= f.label "Upload an Image"%><br></div><br>
-  <div><%= f.file_field :image %><br></div><br>
-  <div><%= f.submit "Submit Photo" %></div><br>
-<% end %>
-  </div>
+    <div><%= f.label "Upload an Image"%><br></div><br>
+    <div><%= f.file_field :image %><br></div><br>
+    <div><%= f.submit "Submit Photo" %></div><br>
+  <% end %>
+</div>

--- a/app/views/stores/admin/show.html.erb
+++ b/app/views/stores/admin/show.html.erb
@@ -11,4 +11,5 @@
     <% end %>
     <p><%= link_to "All Photos", store_admin_photos_path %><br></p>
     <p><%= link_to "Add New Photo", new_store_admin_photo_path %><br></p>
+    <p><%= link_to "Edit Store Info", edit_store_path(current_user.store) %></p>
   </div>

--- a/app/views/stores/edit.html.erb
+++ b/app/views/stores/edit.html.erb
@@ -6,7 +6,7 @@
     <div><%= f.text_field :description, placeholder: "Store description" %><br></div><br>
     <div><%= f.label "Upload an Image"%><br></div><br>
     <div><%= f.file_field :image %><br></div><br>
-    <div><%= f.submit "Update Photo" %></div><br>
+    <div><%= f.submit "Update Store" %></div><br>
   <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,8 @@ Rails.application.routes.draw do
   get "/home", to: "home#index"
   get ":store/admin/:id/dashboard", to: "stores/admin#show", as: "store_admin_dashboard"
 
-  resources :stores, path: ':store', as: :store
+  get ":id/edit", to: "stores#edit", as: :edit_store
+  put ":id", to: "stores#update", as: :store
 
   namespace :stores, path: ':store', as: :store do
     resources :photos,  only: [:index, :show]


### PR DESCRIPTION
Store admin users need to edit their stores due to the pivot spec
Links in the nav bar for All Photos and Create photos were broken due to not passing in the store slug
We should have had tests for the nav bar links

The reason why we changed the route to be :id instead of :store was because this is editing a store specifically,
and the store id is the same regardless of the slug for :store
